### PR TITLE
[fix] 프롬프트 추가 관련 api 수정사항 반영

### DIFF
--- a/src/main/java/org/dgu/programbook/domain/movie/dto/request/CreateMovieRequest.java
+++ b/src/main/java/org/dgu/programbook/domain/movie/dto/request/CreateMovieRequest.java
@@ -1,7 +1,7 @@
 package org.dgu.programbook.domain.movie.dto.request;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.util.List;
 
 public record CreateMovieRequest(
         String title,
@@ -9,6 +9,8 @@ public record CreateMovieRequest(
         String genre,
         LocalDate releaseDate,
         String actor,
-        Long totalParts
+        Long totalParts,
+        List<String> custom_prompts,
+        List<String> custom_retrievals
 ) {
 }

--- a/src/main/java/org/dgu/programbook/domain/movie/dto/request/CreateMovieRequest.java
+++ b/src/main/java/org/dgu/programbook/domain/movie/dto/request/CreateMovieRequest.java
@@ -10,7 +10,7 @@ public record CreateMovieRequest(
         LocalDate releaseDate,
         String actor,
         Long totalParts,
-        List<String> custom_prompts,
-        List<String> custom_retrievals
+        List<String> customPrompts,
+        List<String> customRetrievals
 ) {
 }

--- a/src/main/java/org/dgu/programbook/domain/movie/dto/response/AnalysisResponse.java
+++ b/src/main/java/org/dgu/programbook/domain/movie/dto/response/AnalysisResponse.java
@@ -2,9 +2,10 @@ package org.dgu.programbook.domain.movie.dto.response;
 
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class AnalysisResponse {
+    private List<String> prompt2results;
     private String thumbnail_folder_uri;
-    private String final_story;
-    private String final_review;
 }

--- a/src/main/java/org/dgu/programbook/domain/movie/dto/response/ReadMovieDetailResponse.java
+++ b/src/main/java/org/dgu/programbook/domain/movie/dto/response/ReadMovieDetailResponse.java
@@ -3,10 +3,17 @@ package org.dgu.programbook.domain.movie.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 @Getter
 @Builder
 public class ReadMovieDetailResponse {
+    String title;
+    String director;
+    String actor;
+    String genre;
+    LocalDate releaseDate;
     String thumbnailUrl;
     String summary;
-    String review;
+    String reviews;
 }

--- a/src/main/java/org/dgu/programbook/domain/movie/entity/Movie.java
+++ b/src/main/java/org/dgu/programbook/domain/movie/entity/Movie.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.dgu.programbook.domain.user.entity.User;
 import org.dgu.programbook.global.common.BaseTimeEntity;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDate;
 
@@ -39,11 +41,13 @@ public class Movie extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String review;
 
-    @Column(columnDefinition = "TEXT")
-    private String custom_prompts;
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(columnDefinition = "text[]")
+    private String[] custom_prompts;
 
-    @Column(columnDefinition = "TEXT")
-    private String custom_retrievals;
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(columnDefinition = "text[]")
+    private String[] custom_retrievals;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -53,7 +57,7 @@ public class Movie extends BaseTimeEntity {
     @Builder(builderMethodName = "movieBuilder")
     public Movie(User user, String review, String status, String summary, String thumbnailUrl,
                  LocalDate releaseDate, String genre, String actor, String director, String title,
-                 Long id, String custom_prompts, String custom_retrievals) {
+                 Long id, String[] custom_prompts, String[] custom_retrievals) {
         this.user = user;
         this.review = review;
         this.status = status;

--- a/src/main/java/org/dgu/programbook/domain/movie/entity/Movie.java
+++ b/src/main/java/org/dgu/programbook/domain/movie/entity/Movie.java
@@ -39,13 +39,21 @@ public class Movie extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String review;
 
+    @Column(columnDefinition = "TEXT")
+    private String custom_prompts;
+
+    @Column(columnDefinition = "TEXT")
+    private String custom_retrievals;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
 
     @Builder(builderMethodName = "movieBuilder")
-    public Movie(User user, String review, String status, String summary, String thumbnailUrl, LocalDate releaseDate, String genre, String actor, String director, String title, Long id) {
+    public Movie(User user, String review, String status, String summary, String thumbnailUrl,
+                 LocalDate releaseDate, String genre, String actor, String director, String title,
+                 Long id, String custom_prompts, String custom_retrievals) {
         this.user = user;
         this.review = review;
         this.status = status;
@@ -57,6 +65,8 @@ public class Movie extends BaseTimeEntity {
         this.director = director;
         this.title = title;
         this.id = id;
+        this.custom_prompts=custom_prompts;
+        this.custom_retrievals=custom_retrievals;
     }
 
     public void updateAnalysisResult(String thumbnailUrl, String review ,String summary) {

--- a/src/main/java/org/dgu/programbook/domain/movie/entity/Movie.java
+++ b/src/main/java/org/dgu/programbook/domain/movie/entity/Movie.java
@@ -43,11 +43,15 @@ public class Movie extends BaseTimeEntity {
 
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(columnDefinition = "text[]")
-    private String[] custom_prompts;
+    private String[] customPrompts;
 
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(columnDefinition = "text[]")
-    private String[] custom_retrievals;
+    private String[] customRetrievals;
+
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(columnDefinition = "text[]")
+    private String[] customResults;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -57,7 +61,7 @@ public class Movie extends BaseTimeEntity {
     @Builder(builderMethodName = "movieBuilder")
     public Movie(User user, String review, String status, String summary, String thumbnailUrl,
                  LocalDate releaseDate, String genre, String actor, String director, String title,
-                 Long id, String[] custom_prompts, String[] custom_retrievals) {
+                 Long id, String[] customPrompts, String[] customRetrievals) {
         this.user = user;
         this.review = review;
         this.status = status;
@@ -69,14 +73,13 @@ public class Movie extends BaseTimeEntity {
         this.director = director;
         this.title = title;
         this.id = id;
-        this.custom_prompts=custom_prompts;
-        this.custom_retrievals=custom_retrievals;
+        this.customPrompts=customPrompts;
+        this.customRetrievals=customRetrievals;
     }
 
-    public void updateAnalysisResult(String thumbnailUrl, String review ,String summary) {
+    public void updateAnalysisResult(String thumbnailUrl, String[] customResults) {
         this.thumbnailUrl = thumbnailUrl;
-        this.review = review;
-        this.summary = summary;
+        this.customResults=customResults;
     }
 
     public void updateStatus(String status) {

--- a/src/main/java/org/dgu/programbook/domain/movie/service/AnalysisAsyncService.java
+++ b/src/main/java/org/dgu/programbook/domain/movie/service/AnalysisAsyncService.java
@@ -26,8 +26,7 @@ public class AnalysisAsyncService {
             // 분석 결과 저장
             movie.updateAnalysisResult(
                     analysis.getThumbnail_folder_uri(),
-                    analysis.getFinal_review(),
-                    analysis.getFinal_story()
+                    analysis.getPrompt2results().toArray(new String[0])
             );
 
             movieRepository.save(movie);

--- a/src/main/java/org/dgu/programbook/domain/movie/service/MovieService.java
+++ b/src/main/java/org/dgu/programbook/domain/movie/service/MovieService.java
@@ -96,10 +96,6 @@ public class MovieService {
 
         log.info("createMovieRequest: " + createMovieRequest);
 
-        //리스트 묶어서 처리
-        String prompts = "{" + createMovieRequest.custom_prompts().stream().map(s -> "\"" + s + "\"").collect(Collectors.joining(",")) + "}";
-        String retrievals = "{" + createMovieRequest.custom_retrievals().stream().map(s -> "\"" + s + "\"").collect(Collectors.joining(",")) + "}";
-
         // 1. 영화 정보 저장
         Movie movie = Movie.movieBuilder()
                 .user(user)
@@ -109,8 +105,8 @@ public class MovieService {
                 .director(createMovieRequest.director())
                 .genre(createMovieRequest.genre())
                 .status("UPLOADING")
-                .custom_prompts(prompts)
-                .custom_retrievals(retrievals)
+                .custom_prompts(createMovieRequest.custom_prompts().toArray(new String[0]))
+                .custom_retrievals(createMovieRequest.custom_retrievals().toArray(new String[0]))
                 .build();
 
         movieRepository.save(movie);

--- a/src/main/java/org/dgu/programbook/domain/movie/service/MovieService.java
+++ b/src/main/java/org/dgu/programbook/domain/movie/service/MovieService.java
@@ -105,8 +105,8 @@ public class MovieService {
                 .director(createMovieRequest.director())
                 .genre(createMovieRequest.genre())
                 .status("UPLOADING")
-                .custom_prompts(createMovieRequest.custom_prompts().toArray(new String[0]))
-                .custom_retrievals(createMovieRequest.custom_retrievals().toArray(new String[0]))
+                .customPrompts(createMovieRequest.customPrompts().toArray(new String[0]))
+                .customRetrievals(createMovieRequest.customRetrievals().toArray(new String[0]))
                 .build();
 
         movieRepository.save(movie);

--- a/src/main/java/org/dgu/programbook/domain/movie/service/MovieService.java
+++ b/src/main/java/org/dgu/programbook/domain/movie/service/MovieService.java
@@ -96,6 +96,10 @@ public class MovieService {
 
         log.info("createMovieRequest: " + createMovieRequest);
 
+        //리스트 묶어서 처리
+        String prompts = "{" + createMovieRequest.custom_prompts().stream().map(s -> "\"" + s + "\"").collect(Collectors.joining(",")) + "}";
+        String retrievals = "{" + createMovieRequest.custom_retrievals().stream().map(s -> "\"" + s + "\"").collect(Collectors.joining(",")) + "}";
+
         // 1. 영화 정보 저장
         Movie movie = Movie.movieBuilder()
                 .user(user)
@@ -105,6 +109,8 @@ public class MovieService {
                 .director(createMovieRequest.director())
                 .genre(createMovieRequest.genre())
                 .status("UPLOADING")
+                .custom_prompts(prompts)
+                .custom_retrievals(retrievals)
                 .build();
 
         movieRepository.save(movie);

--- a/src/main/java/org/dgu/programbook/domain/movie/service/MovieService.java
+++ b/src/main/java/org/dgu/programbook/domain/movie/service/MovieService.java
@@ -76,9 +76,14 @@ public class MovieService {
 
         // 4. DTO로 변환 및 반환
         return ReadMovieDetailResponse.builder()
+                .title(movie.getTitle())
+                .director(movie.getDirector())
+                .actor(movie.getActor())
+                .genre(movie.getGenre())
+                .releaseDate(movie.getReleaseDate())
                 .thumbnailUrl(movie.getThumbnailUrl())
                 .summary(movie.getSummary())
-                .review(movie.getReview())
+                .reviews(movie.getReview())
                 .build();
     }
 

--- a/src/main/java/org/dgu/programbook/domain/movie/util/RestClientUtil.java
+++ b/src/main/java/org/dgu/programbook/domain/movie/util/RestClientUtil.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.beans.factory.annotation.Value;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 @Component
@@ -30,13 +31,14 @@ public class RestClientUtil {
     public AnalysisResponse requestAnalysis(String videoPartUrls, Movie movie) {
         Map<String, Object> body = Map.of(
                 "s3_video_uri", videoPartUrls,
+                "characters_info", movie.getActor(),
                 "movie_id", movie.getId(),
                 "segment_duration", 600,
-                "characters_info", movie.getActor(),
+                "init", false,
                 "language_code", "ko-KR",
                 "threshold", 30,
-                "init", true
-
+                "custom_prompts", Arrays.asList(movie.getCustom_prompts()),
+                "custom_retrievals", Arrays.asList(movie.getCustom_retrievals())
         );
 
         ResponseEntity<AnalysisResponse> responseEntity = restClient.post()

--- a/src/main/java/org/dgu/programbook/domain/movie/util/RestClientUtil.java
+++ b/src/main/java/org/dgu/programbook/domain/movie/util/RestClientUtil.java
@@ -37,8 +37,8 @@ public class RestClientUtil {
                 "init", false,
                 "language_code", "ko-KR",
                 "threshold", 30,
-                "custom_prompts", Arrays.asList(movie.getCustom_prompts()),
-                "custom_retrievals", Arrays.asList(movie.getCustom_retrievals())
+                "custom_prompts", Arrays.asList(movie.getCustomPrompts()),
+                "custom_retrievals", Arrays.asList(movie.getCustomRetrievals())
         );
 
         ResponseEntity<AnalysisResponse> responseEntity = restClient.post()


### PR DESCRIPTION
## ✨ Related Issues
- Resolves: #37 

## 📌 Tasks
- 프롬프트 관련 필드들 추가 
- `영상 분석 정보 단일 조회 API`에서 영화 정보 Response 추가
- `영화 멀티 파트 URL 만들기 API`에서 영화 정보 보낼 때 프롬프트 관련 리스트 Request에 추가
- `AI 분석 API`에서 Request, Response 수정

## 참고사항
- 프롬프트 요청 & 응답 필드는 하나의 배열 필드 TEXT[] 형태로 관리하고 있음 (프롬프트 여러 개 중 개별 응답 업데이트라던가 이런 기능 추가되면 수정 필요)
- AI 분석 API는 테스트 돌려봐야함!
- YML 업데이트 plz
